### PR TITLE
Make librbd FileImageCache multi-threading

### DIFF
--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -158,6 +158,7 @@ namespace librbd {
     EventSocket event_socket;
 
     ContextWQ *op_work_queue;
+    ContextWQ *pcache_op_work_queue; //chendi: used for multi process cache op
 
     // Configuration
     static const string METADATA_CONF_PREFIX;

--- a/src/librbd/cache/BlockGuard.h
+++ b/src/librbd/cache/BlockGuard.h
@@ -59,13 +59,38 @@ public:
   };
   typedef std::vector<BlockIOExtent> BlockIOExtents;
 
+  struct C_BlockIORequest : public Context {
+    CephContext *cct;
+    C_BlockIORequest *next_block_request;
+  
+    C_BlockIORequest(CephContext *cct, C_BlockIORequest *next_block_request)
+      : cct(cct), next_block_request(next_block_request) {
+    }
+  
+    virtual void finish(int r) override {
+      //ldout(cct, 20) << "(" << get_name() << "): r=" << r << dendl;
+  
+      if (r < 0) {
+        // abort the chain of requests upon failure
+        next_block_request->complete(r);
+      } else {
+        // execute next request in chain
+        next_block_request->send();
+      }
+    }
+  
+    virtual void send() = 0;
+    virtual const char *get_name() const = 0;
+  };
+
   struct BlockIO {
     // TODO intrusive_list
 
-    BlockIO() {
+    BlockIO()
+      : tail_block_io_request(nullptr), in_process(false) {
     }
     BlockIO(uint64_t block, BlockIOExtents &&extents)
-      : block(block), extents(extents) {
+      : block(block), extents(extents), tail_block_io_request(nullptr), in_process(false) {
     }
 
     uint64_t tid;
@@ -75,6 +100,8 @@ public:
     IOType io_type : 2;     ///< IO type for deferred IO request
     bool partial_block : 1; ///< true if not full block request
     C_BlockRequest *block_request;
+    C_BlockIORequest *tail_block_io_request; ///< used to track ios on this block
+    bool in_process;        ///< true if this block has been in processing by thread
   };
   typedef std::list<BlockIO> BlockIOs;
 

--- a/src/librbd/cache/FileImageCache.cc
+++ b/src/librbd/cache/FileImageCache.cc
@@ -44,40 +44,38 @@ bool is_block_aligned(const ImageCache::Extents &image_extents) {
   return true;
 }
 
-struct C_BlockIORequest : public Context {
-  CephContext *cct;
-  C_BlockIORequest *next_block_request;
+class ThreadPoolSingleton : public ThreadPool {
+public:
+  ContextWQ *pcache_op_work_queue;
 
-  C_BlockIORequest(CephContext *cct, C_BlockIORequest *next_block_request)
-    : cct(cct), next_block_request(next_block_request) {
+  explicit ThreadPoolSingleton(CephContext *cct)
+    : ThreadPool(cct, "librbd::cache::thread_pool", "tp_librbd_cache", 32,
+                 "pcache_threads"),
+      pcache_op_work_queue(new ContextWQ("librbd::pcache_op_work_queue",
+                                  cct->_conf->rbd_op_thread_timeout,
+                                  this)) {
+    start();
   }
+  ~ThreadPoolSingleton() override {
+    pcache_op_work_queue->drain();
+    delete pcache_op_work_queue;
 
-  virtual void finish(int r) override {
-    ldout(cct, 20) << "(" << get_name() << "): r=" << r << dendl;
-
-    if (r < 0) {
-      // abort the chain of requests upon failure
-      next_block_request->complete(r);
-    } else {
-      // execute next request in chain
-      next_block_request->send();
-    }
+    stop();
   }
-
-  virtual void send() = 0;
-  virtual const char *get_name() const = 0;
 };
 
-struct C_ReleaseBlockGuard : public C_BlockIORequest {
+struct C_ReleaseBlockGuard : public BlockGuard::C_BlockIORequest {
   uint64_t block;
   ReleaseBlock &release_block;
   BlockGuard::C_BlockRequest *block_request;
+  BlockGuard::BlockIO block_io;
 
   C_ReleaseBlockGuard(CephContext *cct, uint64_t block,
                       ReleaseBlock &release_block,
-                      BlockGuard::C_BlockRequest *block_request)
+                      BlockGuard::C_BlockRequest *block_request,
+		      BlockGuard::BlockIO &&block_io)
     : C_BlockIORequest(cct, nullptr), block(block),
-      release_block(release_block), block_request(block_request) {
+      release_block(release_block), block_request(block_request), block_io(block_io) {
   }
 
   virtual void send() override {
@@ -88,18 +86,27 @@ struct C_ReleaseBlockGuard : public C_BlockIORequest {
   }
 
   virtual void finish(int r) override {
-    ldout(cct, 20) << "(" << get_name() << "): r=" << r << dendl;
+    ldout(cct, 1) << "(" << get_name() << "): block_io = " << block_io.block << ", r=" << r << dendl;
 
+    if(next_block_request == nullptr 
+	&& block_io.tail_block_io_request == this) {
+      block_io.tail_block_io_request = nullptr;
+      block_io.in_process = false;
+    }
     // IO operation finished -- release guard
     release_block(block);
 
     // complete block request
     block_request->complete_request(r);
+
+    if(next_block_request != nullptr) {
+      next_block_request->send();
+    }
   }
 };
 
 template <typename I>
-struct C_PromoteToCache : public C_BlockIORequest {
+struct C_PromoteToCache : public BlockGuard::C_BlockIORequest {
   ImageStore<I> &image_store;
   uint64_t block;
   const bufferlist &bl;
@@ -125,7 +132,7 @@ struct C_PromoteToCache : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_DemoteFromCache : public C_BlockIORequest {
+struct C_DemoteFromCache : public BlockGuard::C_BlockIORequest {
   ImageStore<I> &image_store;
   ReleaseBlock &release_block;
   uint64_t block;
@@ -155,7 +162,7 @@ struct C_DemoteFromCache : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_ReadFromCacheRequest : public C_BlockIORequest {
+struct C_ReadFromCacheRequest : public BlockGuard::C_BlockIORequest {
   ImageStore<I> &image_store;
   BlockGuard::BlockIO block_io;
   ExtentBuffers *extent_buffers;
@@ -187,7 +194,7 @@ struct C_ReadFromCacheRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_ReadFromImageRequest : public C_BlockIORequest {
+struct C_ReadFromImageRequest : public BlockGuard::C_BlockIORequest {
   ImageWriteback<I> &image_writeback;
   BlockGuard::BlockIO block_io;
   ExtentBuffers *extent_buffers;
@@ -222,7 +229,7 @@ struct C_ReadFromImageRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_WriteToMetaRequest : public C_BlockIORequest {
+struct C_WriteToMetaRequest : public BlockGuard::C_BlockIORequest {
   MetaStore<I> &meta_store;
   uint64_t cache_block_id;
   Policy *policy;
@@ -249,7 +256,7 @@ struct C_WriteToMetaRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_WriteToImageRequest : public C_BlockIORequest {
+struct C_WriteToImageRequest : public BlockGuard::C_BlockIORequest {
   ImageWriteback<I> &image_writeback;
   BlockGuard::BlockIO block_io;
   const bufferlist &bl;
@@ -287,7 +294,7 @@ struct C_WriteToImageRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_ReadBlockFromCacheRequest : public C_BlockIORequest {
+struct C_ReadBlockFromCacheRequest : public BlockGuard::C_BlockIORequest {
   ImageStore<I> &image_store;
   uint64_t block;
   uint32_t block_size;
@@ -313,7 +320,7 @@ struct C_ReadBlockFromCacheRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_ReadBlockFromImageRequest : public C_BlockIORequest {
+struct C_ReadBlockFromImageRequest : public BlockGuard::C_BlockIORequest {
   ImageWriteback<I> &image_writeback;
   uint64_t block;
   bufferlist *block_bl;
@@ -338,7 +345,7 @@ struct C_ReadBlockFromImageRequest : public C_BlockIORequest {
   }
 };
 
-struct C_CopyFromBlockBuffer : public C_BlockIORequest {
+struct C_CopyFromBlockBuffer : public BlockGuard::C_BlockIORequest {
   BlockGuard::BlockIO block_io;
   const bufferlist &block_bl;
   ExtentBuffers *extent_buffers;
@@ -366,7 +373,7 @@ struct C_CopyFromBlockBuffer : public C_BlockIORequest {
   }
 };
 
-struct C_ModifyBlockBuffer : public C_BlockIORequest {
+struct C_ModifyBlockBuffer : public BlockGuard::C_BlockIORequest {
   BlockGuard::BlockIO block_io;
   const bufferlist &bl;
   bufferlist *block_bl;
@@ -411,7 +418,7 @@ struct C_ModifyBlockBuffer : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_AppendEventToJournal : public C_BlockIORequest {
+struct C_AppendEventToJournal : public BlockGuard::C_BlockIORequest {
   JournalStore<I> &journal_store;
   uint64_t tid;
   uint64_t block;
@@ -437,7 +444,7 @@ struct C_AppendEventToJournal : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_DemoteBlockToJournal : public C_BlockIORequest {
+struct C_DemoteBlockToJournal : public BlockGuard::C_BlockIORequest {
   JournalStore<I> &journal_store;
   uint64_t block;
   const bufferlist &bl;
@@ -492,8 +499,14 @@ struct C_ReadBlockRequest : public BlockGuard::C_BlockRequest {
     // have 1024 4K requests to read a single object)
 
     // NOTE: block guard active -- must be released after IO completes
-    C_BlockIORequest *req = new C_ReleaseBlockGuard(cct, block_io.block,
-                                                         release_block, this);
+    BlockGuard::C_BlockIORequest *req = new C_ReleaseBlockGuard(cct, block_io.block,
+                                                         release_block, this, std::move(block_io));
+    BlockGuard::C_BlockIORequest *orig_tail_block_io_req = nullptr;
+    if(block_io.tail_block_io_request != nullptr) {
+      orig_tail_block_io_req = block_io.tail_block_io_request;
+    }
+    block_io.tail_block_io_request = req;
+
     switch (policy_map_result) {
     case POLICY_MAP_RESULT_HIT:
       req = new C_ReadFromCacheRequest<I>(cct, image_store, std::move(block_io),
@@ -522,7 +535,20 @@ struct C_ReadBlockRequest : public BlockGuard::C_BlockRequest {
     default:
       assert(false);
     }
-    req->send();
+    //chendi: schedule send on another tread, and check if we can continue
+    if(orig_tail_block_io_req != nullptr)
+      orig_tail_block_io_req->next_block_request = req;
+    if(!block_io.in_process) {
+      ldout(cct, 20) << "block_io: "<< block_io.block << " is not in process, will schedule" << dendl;
+      block_io.in_process = true;
+      image_ctx.pcache_op_work_queue->queue(new FunctionContext( 
+        [req](int r) {
+	  req->send();
+	}), 0);
+    }else{
+      ldout(cct, 20) << "block_io: "<< block_io.block << " is in process, skip schedule" << dendl;
+    }
+    //req->send();
   }
 
   virtual void finish(int r) override {
@@ -580,8 +606,13 @@ struct C_WriteBlockRequest : BlockGuard::C_BlockRequest {
     // have 1024 4K requests to read a single object)
 
     // NOTE: block guard active -- must be released after IO completes
-    C_BlockIORequest *req = new C_ReleaseBlockGuard(cct, block_io.block,
-                                                         release_block, this);
+    BlockGuard::C_BlockIORequest *req = new C_ReleaseBlockGuard(cct, block_io.block,
+                                                         release_block, this, std::move(block_io));
+    BlockGuard::C_BlockIORequest *orig_tail_block_io_req = nullptr;
+    if(block_io.tail_block_io_request!=nullptr) {
+      orig_tail_block_io_req = block_io.tail_block_io_request;
+    }
+    block_io.tail_block_io_request = req;
 
     if (policy_map_result == POLICY_MAP_RESULT_MISS) {
       req = new C_WriteToImageRequest<I>(cct, image_writeback,
@@ -653,7 +684,20 @@ struct C_WriteBlockRequest : BlockGuard::C_BlockRequest {
                                        block_io.block, req);
       }
     }
-    req->send();
+    //req->send();
+    //chendi: schedule send on another tread, and check if we can continue
+    if (orig_tail_block_io_req != nullptr)
+      orig_tail_block_io_req->next_block_request = req;
+    if(!block_io.in_process) {
+      ldout(cct, 1) << "block_io: "<< block_io.block << " is not in process, will schedule" << dendl;
+      block_io.in_process = true;
+      image_ctx.pcache_op_work_queue->queue(new FunctionContext( 
+        [req](int r) { 
+	  req->send(); 
+	}), 0);
+    }else{
+      ldout(cct, 1) << "block_io: "<< block_io.block << " is in process, will skip schedule" << dendl;
+    }
   }
 };
 
@@ -809,6 +853,12 @@ FileImageCache<I>::FileImageCache(ImageCtx &image_ctx)
   CephContext *cct = m_image_ctx.cct;
   uint8_t write_mode = cct->_conf->rbd_persistent_cache_enabled?1:0;
   m_policy->set_write_mode(write_mode);
+  //chendi: create threadpool for parallel cache process
+  ThreadPoolSingleton *thread_pool_singleton;
+  cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
+    thread_pool_singleton, "librbd::cache::thread_pool");
+  m_image_ctx.pcache_op_work_queue = thread_pool_singleton->pcache_op_work_queue; 
+  
 }
 
 template <typename I>


### PR DESCRIPTION
C_BlockIORequest of same BlockIO will be processed sequentially,
while C_BlockIORequest of different BlockIO will be scheduled
to different thread and be processed parallel.

For example:
ReqQueue: 1:block_a, 2:block_c, 3:block_a, 4:block_b, 5:block_c, ...
after map_block and remap
block_a:
1.promote_to_cache->1.promote_to_meta->1.release_block_guard
->3.promote_to_cache->3.promote_to_meta->3.release_block_guard
block_b:
4.promote_to_cache->4.promote_to_meta->4.release_block_guard
block_c:
2.promote_to_cache->2.promote_to_meta->2.release_block_guard
->5.promote_to_cache->5.promote_to_meta->5.release_block_guard

So req 3 will wait until req 1 complete, while req 4 and req 2 will
be processed once the req arrive.

Signed-off-by: Chendi Xue <chendi.xue@intel.com>