### PR TITLE
Wip librbd cache

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -29,7 +29,7 @@ set(librbd_internal_srcs
   cache/BlockGuard.cc
   cache/ImageWriteback.cc
   cache/FileImageCache.cc
-  cache/file/AioFile.cc
+  cache/file/SyncFile.cc
   cache/file/ImageStore.cc
   cache/file/JournalStore.cc
   cache/file/MetaStore.cc

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -158,6 +158,7 @@ namespace librbd {
     EventSocket event_socket;
 
     ContextWQ *op_work_queue;
+    ContextWQ *pcache_op_work_queue; //chendi: used for multi process cache op
 
     // Configuration
     static const string METADATA_CONF_PREFIX;

--- a/src/librbd/cache/BlockGuard.cc
+++ b/src/librbd/cache/BlockGuard.cc
@@ -75,7 +75,7 @@ void BlockGuard::create_block_ios(IOType io_type,
 
 int BlockGuard::detain(uint64_t block, BlockIO *block_io) {
   Mutex::Locker locker(m_lock);
-  ldout(m_cct, 20) << "block=" << block << ", "
+  ldout(m_cct, 1) << "block=" << block << ", "
                    << "free_slots=" << m_free_detained_blocks.size() << dendl;
   assert(block_io == nullptr || block == block_io->block);
 
@@ -97,7 +97,7 @@ int BlockGuard::detain(uint64_t block, BlockIO *block_io) {
     return 1;
   } else {
     if (m_free_detained_blocks.empty()) {
-      ldout(m_cct, 20) << "no free detained block cells" << dendl;
+      ldout(m_cct, 1) << "no free detained block cells" << dendl;
       return -ENOMEM;
     }
 
@@ -116,7 +116,7 @@ int BlockGuard::release(uint64_t block, BlockIOs *block_ios) {
   assert(detained_block_it != m_detained_blocks.end());
 
   auto &detained_block = *detained_block_it;
-  ldout(m_cct, 20) << "block=" << block << ", "
+  ldout(m_cct, 1) << "block=" << block << ", "
                    << "pending_ios="
                    << (detained_block.block_ios.empty() ?
                         0 : detained_block.block_ios.size() - 1) << ", "

--- a/src/librbd/cache/BlockGuard.h
+++ b/src/librbd/cache/BlockGuard.h
@@ -59,13 +59,38 @@ public:
   };
   typedef std::vector<BlockIOExtent> BlockIOExtents;
 
+  struct C_BlockIORequest : public Context {
+    CephContext *cct;
+    C_BlockIORequest *next_block_request;
+  
+    C_BlockIORequest(CephContext *cct, C_BlockIORequest *next_block_request)
+      : cct(cct), next_block_request(next_block_request) {
+    }
+  
+    virtual void finish(int r) override {
+      //ldout(cct, 20) << "(" << get_name() << "): r=" << r << dendl;
+  
+      if (r < 0) {
+        // abort the chain of requests upon failure
+        next_block_request->complete(r);
+      } else {
+        // execute next request in chain
+        next_block_request->send();
+      }
+    }
+  
+    virtual void send() = 0;
+    virtual const char *get_name() const = 0;
+  };
+
   struct BlockIO {
     // TODO intrusive_list
 
-    BlockIO() {
+    BlockIO()
+      : tail_block_io_request(nullptr), in_process(false) {
     }
     BlockIO(uint64_t block, BlockIOExtents &&extents)
-      : block(block), extents(extents) {
+      : block(block), extents(extents), tail_block_io_request(nullptr), in_process(false) {
     }
 
     uint64_t tid;
@@ -75,6 +100,8 @@ public:
     IOType io_type : 2;     ///< IO type for deferred IO request
     bool partial_block : 1; ///< true if not full block request
     C_BlockRequest *block_request;
+    C_BlockIORequest *tail_block_io_request; ///< used to track ios on this block
+    bool in_process;        ///< true if this block has been in processing by thread
   };
   typedef std::list<BlockIO> BlockIOs;
 

--- a/src/librbd/cache/FileImageCache.cc
+++ b/src/librbd/cache/FileImageCache.cc
@@ -44,40 +44,38 @@ bool is_block_aligned(const ImageCache::Extents &image_extents) {
   return true;
 }
 
-struct C_BlockIORequest : public Context {
-  CephContext *cct;
-  C_BlockIORequest *next_block_request;
+class ThreadPoolSingleton : public ThreadPool {
+public:
+  ContextWQ *pcache_op_work_queue;
 
-  C_BlockIORequest(CephContext *cct, C_BlockIORequest *next_block_request)
-    : cct(cct), next_block_request(next_block_request) {
+  explicit ThreadPoolSingleton(CephContext *cct)
+    : ThreadPool(cct, "librbd::cache::thread_pool", "tp_librbd_cache", 32,
+                 "pcache_threads"),
+      pcache_op_work_queue(new ContextWQ("librbd::pcache_op_work_queue",
+                                  cct->_conf->rbd_op_thread_timeout,
+                                  this)) {
+    start();
   }
+  ~ThreadPoolSingleton() override {
+    pcache_op_work_queue->drain();
+    delete pcache_op_work_queue;
 
-  virtual void finish(int r) override {
-    ldout(cct, 20) << "(" << get_name() << "): r=" << r << dendl;
-
-    if (r < 0) {
-      // abort the chain of requests upon failure
-      next_block_request->complete(r);
-    } else {
-      // execute next request in chain
-      next_block_request->send();
-    }
+    stop();
   }
-
-  virtual void send() = 0;
-  virtual const char *get_name() const = 0;
 };
 
-struct C_ReleaseBlockGuard : public C_BlockIORequest {
+struct C_ReleaseBlockGuard : public BlockGuard::C_BlockIORequest {
   uint64_t block;
   ReleaseBlock &release_block;
   BlockGuard::C_BlockRequest *block_request;
+  BlockGuard::BlockIO block_io;
 
   C_ReleaseBlockGuard(CephContext *cct, uint64_t block,
                       ReleaseBlock &release_block,
-                      BlockGuard::C_BlockRequest *block_request)
+                      BlockGuard::C_BlockRequest *block_request,
+		      BlockGuard::BlockIO &&block_io)
     : C_BlockIORequest(cct, nullptr), block(block),
-      release_block(release_block), block_request(block_request) {
+      release_block(release_block), block_request(block_request), block_io(block_io) {
   }
 
   virtual void send() override {
@@ -88,18 +86,27 @@ struct C_ReleaseBlockGuard : public C_BlockIORequest {
   }
 
   virtual void finish(int r) override {
-    ldout(cct, 20) << "(" << get_name() << "): r=" << r << dendl;
+    ldout(cct, 1) << "(" << get_name() << "): block_io = " << block_io.block << ", r=" << r << dendl;
 
+    if(next_block_request == nullptr 
+	&& block_io.tail_block_io_request == this) {
+      block_io.tail_block_io_request = nullptr;
+      block_io.in_process = false;
+    }
     // IO operation finished -- release guard
     release_block(block);
 
     // complete block request
     block_request->complete_request(r);
+
+    if(next_block_request != nullptr) {
+      next_block_request->send();
+    }
   }
 };
 
 template <typename I>
-struct C_PromoteToCache : public C_BlockIORequest {
+struct C_PromoteToCache : public BlockGuard::C_BlockIORequest {
   ImageStore<I> &image_store;
   BlockGuard::BlockIO block_io;
   const bufferlist &bl;
@@ -130,7 +137,7 @@ struct C_PromoteToCache : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_DemoteFromCache : public C_BlockIORequest {
+struct C_DemoteFromCache : public BlockGuard::C_BlockIORequest {
   ImageStore<I> &image_store;
   ReleaseBlock &release_block;
   uint64_t block;
@@ -160,7 +167,7 @@ struct C_DemoteFromCache : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_ReadFromCacheRequest : public C_BlockIORequest {
+struct C_ReadFromCacheRequest : public BlockGuard::C_BlockIORequest {
   ImageStore<I> &image_store;
   BlockGuard::BlockIO block_io;
   ExtentBuffers *extent_buffers;
@@ -192,7 +199,7 @@ struct C_ReadFromCacheRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_ReadFromImageRequest : public C_BlockIORequest {
+struct C_ReadFromImageRequest : public BlockGuard::C_BlockIORequest {
   ImageWriteback<I> &image_writeback;
   BlockGuard::BlockIO block_io;
   ExtentBuffers *extent_buffers;
@@ -227,7 +234,7 @@ struct C_ReadFromImageRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_WriteToMetaRequest : public C_BlockIORequest {
+struct C_WriteToMetaRequest : public BlockGuard::C_BlockIORequest {
   MetaStore<I> &meta_store;
   uint64_t cache_block_id;
   Policy *policy;
@@ -254,7 +261,7 @@ struct C_WriteToMetaRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_WriteToImageRequest : public C_BlockIORequest {
+struct C_WriteToImageRequest : public BlockGuard::C_BlockIORequest {
   ImageWriteback<I> &image_writeback;
   BlockGuard::BlockIO block_io;
   const bufferlist &bl;
@@ -292,7 +299,7 @@ struct C_WriteToImageRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_ReadBlockFromCacheRequest : public C_BlockIORequest {
+struct C_ReadBlockFromCacheRequest : public BlockGuard::C_BlockIORequest {
   ImageStore<I> &image_store;
   uint64_t block;
   uint32_t block_size;
@@ -318,7 +325,7 @@ struct C_ReadBlockFromCacheRequest : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_ReadBlockFromImageRequest : public C_BlockIORequest {
+struct C_ReadBlockFromImageRequest : public BlockGuard::C_BlockIORequest {
   ImageWriteback<I> &image_writeback;
   uint64_t block;
   bufferlist *block_bl;
@@ -343,7 +350,7 @@ struct C_ReadBlockFromImageRequest : public C_BlockIORequest {
   }
 };
 
-struct C_CopyFromBlockBuffer : public C_BlockIORequest {
+struct C_CopyFromBlockBuffer : public BlockGuard::C_BlockIORequest {
   BlockGuard::BlockIO block_io;
   const bufferlist &block_bl;
   ExtentBuffers *extent_buffers;
@@ -371,7 +378,7 @@ struct C_CopyFromBlockBuffer : public C_BlockIORequest {
   }
 };
 
-struct C_ModifyBlockBuffer : public C_BlockIORequest {
+struct C_ModifyBlockBuffer : public BlockGuard::C_BlockIORequest {
   BlockGuard::BlockIO block_io;
   const bufferlist &bl;
   bufferlist *block_bl;
@@ -416,7 +423,7 @@ struct C_ModifyBlockBuffer : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_AppendEventToJournal : public C_BlockIORequest {
+struct C_AppendEventToJournal : public BlockGuard::C_BlockIORequest {
   JournalStore<I> &journal_store;
   uint64_t tid;
   uint64_t block;
@@ -442,7 +449,7 @@ struct C_AppendEventToJournal : public C_BlockIORequest {
 };
 
 template <typename I>
-struct C_DemoteBlockToJournal : public C_BlockIORequest {
+struct C_DemoteBlockToJournal : public BlockGuard::C_BlockIORequest {
   JournalStore<I> &journal_store;
   uint64_t block;
   const bufferlist &bl;
@@ -497,8 +504,14 @@ struct C_ReadBlockRequest : public BlockGuard::C_BlockRequest {
     // have 1024 4K requests to read a single object)
 
     // NOTE: block guard active -- must be released after IO completes
-    C_BlockIORequest *req = new C_ReleaseBlockGuard(cct, block_io.block,
-                                                         release_block, this);
+    BlockGuard::C_BlockIORequest *req = new C_ReleaseBlockGuard(cct, block_io.block,
+                                                         release_block, this, std::move(block_io));
+    BlockGuard::C_BlockIORequest *orig_tail_block_io_req = nullptr;
+    if(block_io.tail_block_io_request != nullptr) {
+      orig_tail_block_io_req = block_io.tail_block_io_request;
+    }
+    block_io.tail_block_io_request = req;
+
     switch (policy_map_result) {
     case POLICY_MAP_RESULT_HIT:
       req = new C_ReadFromCacheRequest<I>(cct, image_store, std::move(block_io),
@@ -527,7 +540,20 @@ struct C_ReadBlockRequest : public BlockGuard::C_BlockRequest {
     default:
       assert(false);
     }
-    req->send();
+    //chendi: schedule send on another tread, and check if we can continue
+    if(orig_tail_block_io_req != nullptr)
+      orig_tail_block_io_req->next_block_request = req;
+    if(!block_io.in_process) {
+      ldout(cct, 20) << "block_io: "<< block_io.block << " is not in process, will schedule" << dendl;
+      block_io.in_process = true;
+      image_ctx.pcache_op_work_queue->queue(new FunctionContext( 
+        [req](int r) {
+	  req->send();
+	}), 0);
+    }else{
+      ldout(cct, 20) << "block_io: "<< block_io.block << " is in process, skip schedule" << dendl;
+    }
+    //req->send();
   }
 
   virtual void finish(int r) override {
@@ -585,8 +611,13 @@ struct C_WriteBlockRequest : BlockGuard::C_BlockRequest {
     // have 1024 4K requests to read a single object)
 
     // NOTE: block guard active -- must be released after IO completes
-    C_BlockIORequest *req = new C_ReleaseBlockGuard(cct, block_io.block,
-                                                         release_block, this);
+    BlockGuard::C_BlockIORequest *req = new C_ReleaseBlockGuard(cct, block_io.block,
+                                                         release_block, this, std::move(block_io));
+    BlockGuard::C_BlockIORequest *orig_tail_block_io_req = nullptr;
+    if(block_io.tail_block_io_request!=nullptr) {
+      orig_tail_block_io_req = block_io.tail_block_io_request;
+    }
+    block_io.tail_block_io_request = req;
 
     if (policy_map_result == POLICY_MAP_RESULT_MISS) {
       req = new C_WriteToImageRequest<I>(cct, image_writeback,
@@ -664,7 +695,20 @@ struct C_WriteBlockRequest : BlockGuard::C_BlockRequest {
                                        block_io.block, req);
       }
     }
-    req->send();
+    //req->send();
+    //chendi: schedule send on another tread, and check if we can continue
+    if (orig_tail_block_io_req != nullptr)
+      orig_tail_block_io_req->next_block_request = req;
+    if(!block_io.in_process) {
+      ldout(cct, 1) << "block_io: "<< block_io.block << " is not in process, will schedule" << dendl;
+      block_io.in_process = true;
+      image_ctx.pcache_op_work_queue->queue(new FunctionContext( 
+        [req](int r) { 
+	  req->send(); 
+	}), 0);
+    }else{
+      ldout(cct, 1) << "block_io: "<< block_io.block << " is in process, will skip schedule" << dendl;
+    }
   }
 };
 
@@ -820,6 +864,12 @@ FileImageCache<I>::FileImageCache(ImageCtx &image_ctx)
   CephContext *cct = m_image_ctx.cct;
   uint8_t write_mode = cct->_conf->rbd_persistent_cache_writeback?1:0;
   m_policy->set_write_mode(write_mode);
+  //chendi: create threadpool for parallel cache process
+  ThreadPoolSingleton *thread_pool_singleton;
+  cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
+    thread_pool_singleton, "librbd::cache::thread_pool");
+  m_image_ctx.pcache_op_work_queue = thread_pool_singleton->pcache_op_work_queue; 
+  
 }
 
 template <typename I>

--- a/src/librbd/cache/FileImageCache.cc
+++ b/src/librbd/cache/FileImageCache.cc
@@ -119,7 +119,7 @@ struct C_PromoteToCache : public BlockGuard::C_BlockIORequest {
   }
 
   virtual void send() override {
-    ldout(cct, 20) << "(" << get_name() << "): "
+    ldout(cct, 1) << "(" << get_name() << "): "
                    << "block=" << block_io.block << dendl;
     // promote the clean block to the cache
     bufferlist sub_bl;
@@ -247,7 +247,7 @@ struct C_WriteToMetaRequest : public BlockGuard::C_BlockIORequest {
   }
 
   virtual void send() override {
-    ldout(cct, 20) << "(" << get_name() << "): "
+    ldout(cct, 1) << "(" << get_name() << "): "
                    << "cache_block_id=" << cache_block_id << dendl;
 
     bufferlist meta_bl;

--- a/src/librbd/cache/FileImageCache.cc
+++ b/src/librbd/cache/FileImageCache.cc
@@ -631,7 +631,7 @@ struct C_WriteBlockRequest : BlockGuard::C_BlockRequest {
         // block is now dirty -- can't be replaced until flushed
         policy.set_dirty(block_io.block);
       }
-      req = new C_WriteToMetaRequest<I>(cct, meta_store, block_io.block, &policy, req);
+      //req = new C_WriteToMetaRequest<I>(cct, meta_store, block_io.block, &policy, req);
 
       IOType io_type = static_cast<IOType>(block_io.io_type);
       if ((io_type == IO_TYPE_WRITE || io_type == IO_TYPE_DISCARD) &&
@@ -1181,7 +1181,7 @@ void FileImageCache<I>::release_block(uint64_t block) {
 
   Mutex::Locker locker(m_lock);
   m_block_guard.release(block, &m_detained_block_ios);
-  wake_up();
+  //wake_up();
 }
 
 template <typename I>
@@ -1214,12 +1214,12 @@ void FileImageCache<I>::wake_up() {
 template <typename I>
 void FileImageCache<I>::process_work() {
   CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 20) << dendl;
+  ldout(cct, 1) << dendl;
 
   do {
-    process_writeback_dirty_blocks();
-    process_detained_block_ios();
-    process_deferred_block_ios();
+    //process_writeback_dirty_blocks();
+    //process_detained_block_ios();
+    //process_deferred_block_ios();
 
     // TODO
     Contexts post_work_contexts;
@@ -1290,7 +1290,7 @@ void FileImageCache<I>::process_detained_block_ios() {
   }
 
   CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 20) << "block_ios=" << block_ios.size() << dendl;
+  ldout(cct, 1) << "block_ios=" << block_ios.size() << dendl;
   for (auto &block_io : block_ios) {
     map_block(false, std::move(block_io));
   }

--- a/src/librbd/cache/file/ImageStore.h
+++ b/src/librbd/cache/file/ImageStore.h
@@ -6,7 +6,7 @@
 
 #include "include/buffer_fwd.h"
 #include "include/int_types.h"
-#include "librbd/cache/file/AioFile.h"
+#include "librbd/cache/file/SyncFile.h"
 #include <vector>
 
 struct Context;
@@ -40,7 +40,7 @@ public:
 private:
   ImageCtxT &m_image_ctx;
   MetaStore<ImageCtxT> &m_metastore;
-  AioFile<ImageCtx> m_cache_file;
+  SyncFile<ImageCtx> m_cache_file;
 
 };
 

--- a/src/librbd/cache/file/JournalStore.h
+++ b/src/librbd/cache/file/JournalStore.h
@@ -5,7 +5,7 @@
 #define CEPH_LIBRBD_CACHE_FILE_JOURNAL_STORE
 
 #include "librbd/cache/Types.h"
-#include "librbd/cache/file/AioFile.h"
+#include "librbd/cache/file/SyncFile.h"
 #include "common/Mutex.h"
 #include <boost/intrusive/slist.hpp>
 #include <boost/intrusive/set.hpp>
@@ -120,8 +120,8 @@ private:
   ImageCtxT &m_image_ctx;
   BlockGuard &m_block_guard;
   MetaStore<ImageCtxT> &m_metastore;
-  AioFile<ImageCtx> m_event_file;
-  AioFile<ImageCtx> m_block_file;
+  SyncFile<ImageCtx> m_event_file;
+  SyncFile<ImageCtx> m_block_file;
 
   mutable Mutex m_lock;
   uint64_t m_tid = 0;

--- a/src/librbd/cache/file/MetaStore.cc
+++ b/src/librbd/cache/file/MetaStore.cc
@@ -41,7 +41,7 @@ void MetaStore<I>::init(bufferlist *bl, Context *on_finish) {
         load_all(bl, on_finish);
       }
     });
-  m_meta_file.open(ctx);
+  m_meta_file.open(ctx, false);
 }
 
 template <typename I>

--- a/src/librbd/cache/file/MetaStore.h
+++ b/src/librbd/cache/file/MetaStore.h
@@ -6,7 +6,7 @@
 
 #include "librbd/cache/Types.h"
 #include "include/int_types.h"
-#include "librbd/cache/file/AioFile.h"
+#include "librbd/cache/file/SyncFile.h"
 #include "common/Mutex.h"
 
 struct Context;
@@ -44,7 +44,7 @@ private:
   uint32_t m_block_size;
   uint32_t m_entry_size;
 
-  AioFile<ImageCtx> m_meta_file;
+  SyncFile<ImageCtx> m_aio_file;
 
 };
 

--- a/src/librbd/cache/file/MetaStore.h
+++ b/src/librbd/cache/file/MetaStore.h
@@ -44,7 +44,7 @@ private:
   uint32_t m_block_size;
   uint32_t m_entry_size;
 
-  SyncFile<ImageCtx> m_aio_file;
+  SyncFile<ImageCtx> m_meta_file;
 
 };
 

--- a/src/librbd/cache/file/StupidPolicy.cc
+++ b/src/librbd/cache/file/StupidPolicy.cc
@@ -264,7 +264,7 @@ void StupidPolicy<I>::tick() {
 
 template <typename I>
 int StupidPolicy<I>::get_entry_size() {
-  return sizeof(struct Entry);
+  return sizeof(uint64_t);
 }
 
 template <typename I>
@@ -281,7 +281,7 @@ void StupidPolicy<I>::entry_to_bufferlist(uint64_t block, bufferlist *bl){
   entry.encode(encode_bl);
   bl->append(encode_bl);
   CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 20) << "block=" << block << " bl=" << *bl << dendl;
+  ldout(cct, 1) << "block=" << block << " encode_bl=" << encode_bl << dendl;
 }
 
 template <typename I>

--- a/src/librbd/cache/file/SyncFile.cc
+++ b/src/librbd/cache/file/SyncFile.cc
@@ -39,10 +39,13 @@ SyncFile<I>::~SyncFile() {
 }
 
 template <typename I>
-void SyncFile<I>::open(Context *on_finish) {
+void SyncFile<I>::open(Context *on_finish, bool sync_flag) {
   while (true) {
-    m_fd = ::open(m_name.c_str(), O_CREAT | O_NOATIME | O_RDWR | O_SYNC,
-                  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    int flag = O_CREAT | O_NOATIME | O_RDWR | O_SYNC;
+    if (!sync_flag){
+        flag = O_CREAT | O_NOATIME | O_RDWR;
+    }
+    m_fd = ::open(m_name.c_str(), flag, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
     if (m_fd == -1) {
       int r = -errno;
       if (r == -EINTR) {
@@ -122,7 +125,7 @@ int SyncFile<I>::write(uint64_t offset, const ceph::bufferlist &bl,
                       bool sync) {
   sync = false;
   CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 20) << "offset=" << offset << ", "
+  ldout(cct, 1) << "offset=" << offset << ", "
                  << "length=" << bl.length() << dendl;
 
   int r = bl.write_fd(m_fd, offset);

--- a/src/librbd/cache/file/SyncFile.cc
+++ b/src/librbd/cache/file/SyncFile.cc
@@ -1,0 +1,246 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/cache/file/SyncFile.h"
+#include "include/Context.h"
+#include "common/dout.h"
+#include "common/WorkQueue.h"
+#include "librbd/ImageCtx.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <aio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <utility>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::file::SyncFile: " << this << " " \
+                           <<  __func__ << ": "
+
+namespace librbd {
+namespace cache {
+namespace file {
+
+template <typename I>
+SyncFile<I>::SyncFile(I &image_ctx, ContextWQ &work_queue,
+                    const std::string &name)
+  : m_image_ctx(image_ctx), m_work_queue(work_queue){
+  CephContext *cct = m_image_ctx.cct;
+  m_name = cct->_conf->rbd_persistent_cache_path + "/rbd_cache." + name;
+}
+
+template <typename I>
+SyncFile<I>::~SyncFile() {
+  // TODO force proper cleanup
+  if (m_fd != -1) {
+    ::close(m_fd);
+  }
+}
+
+template <typename I>
+void SyncFile<I>::open(Context *on_finish) {
+  while (true) {
+    m_fd = ::open(m_name.c_str(), O_CREAT | O_NOATIME | O_RDWR | O_SYNC,
+                  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP);
+    if (m_fd == -1) {
+      int r = -errno;
+      if (r == -EINTR) {
+        continue;
+      }
+      on_finish->complete(r);
+      return;
+    }
+    break;
+  }
+
+  on_finish->complete(0);
+}
+
+template <typename I>
+void SyncFile<I>::close(Context *on_finish) {
+  assert(m_fd >= 0);
+  while (true) {
+    int r = ::close(m_fd);
+    if (r == -1) {
+      r = -errno;
+      if (r == -EINTR) {
+        continue;
+      }
+      on_finish->complete(r);
+      return;
+    }
+    break;
+  }
+
+  m_fd = -1;
+  on_finish->complete(0);
+}
+
+template <typename I>
+void SyncFile<I>::read(uint64_t offset, uint64_t length, ceph::bufferlist *bl,
+                      Context *on_finish) {
+  on_finish->complete(read(offset, length, bl));
+}
+
+template <typename I>
+void SyncFile<I>::write(uint64_t offset, ceph::bufferlist &&bl,
+                       bool fdatasync, Context *on_finish) {
+  on_finish->complete(write(offset, bl, fdatasync));
+  //on_finish->complete(0);
+}
+
+template <typename I>
+void SyncFile<I>::discard(uint64_t offset, uint64_t length, bool fdatasync,
+                         Context *on_finish) {
+  on_finish->complete(discard(offset, length, fdatasync));
+}
+
+template <typename I>
+void SyncFile<I>::truncate(uint64_t length, bool fdatasync, Context *on_finish) {
+  on_finish->complete(truncate(length, fdatasync));
+}
+
+template <typename I>
+void SyncFile<I>::fsync(Context *on_finish) {
+  int r = ::fsync(m_fd);
+  if (r == -1) {
+    r = -errno;
+    on_finish->complete(r);
+    return;
+  }
+  on_finish->complete(0);
+}
+
+template <typename I>
+void SyncFile<I>::fdatasync(Context *on_finish) {
+  on_finish->complete(fdatasync());
+}
+
+template <typename I>
+int SyncFile<I>::write(uint64_t offset, const ceph::bufferlist &bl,
+                      bool sync) {
+  sync = false;
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "offset=" << offset << ", "
+                 << "length=" << bl.length() << dendl;
+
+  int r = bl.write_fd(m_fd, offset);
+  if (r < 0) {
+    return r;
+  }
+
+  if (sync) {
+    r = fdatasync();
+  }
+  return r;
+}
+
+template <typename I>
+int SyncFile<I>::read(uint64_t offset, uint64_t length, ceph::bufferlist *bl) {
+
+  CephContext *cct = m_image_ctx.cct;
+  bufferptr bp = buffer::create(length);
+  bl->push_back(bp);
+
+  int r = 0;
+  char *buffer = reinterpret_cast<char *>(bp.c_str());
+  uint64_t count = 0;
+  while (count < length) {
+    ssize_t ret_val = pread64(m_fd, buffer, length - count, offset + count);
+    if (ret_val == 0) {
+      break;
+    } else if (ret_val < 0) {
+      r = -errno;
+      if (r == -EINTR) {
+        continue;
+      }
+
+      return r;
+    }
+
+    count += ret_val;
+    buffer += ret_val;
+  }
+  return count;
+}
+
+template <typename I>
+int SyncFile<I>::discard(uint64_t offset, uint64_t length, bool sync) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "offset=" << offset << ", "
+                 << "length=" << length << dendl;
+
+  int r;
+  while (true) {
+    r = fallocate(m_fd, FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+                  offset, length);
+    if (r == -1) {
+      r = -errno;
+      if (r == -EINTR) {
+        continue;
+      }
+      return r;
+    }
+    break;
+  }
+
+  if (sync) {
+    r = fdatasync();
+  }
+  return r;
+}
+
+template <typename I>
+int SyncFile<I>::truncate(uint64_t length, bool sync) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "length=" << length << dendl;
+
+  int r;
+  while (true) {
+    r = ftruncate(m_fd, length);
+    if (r == -1) {
+      r = -errno;
+      if (r == -EINTR) {
+        continue;
+      }
+      return r;
+    }
+    break;
+  }
+
+  if (sync) {
+    r = fdatasync();
+  }
+  return r;
+}
+
+template <typename I>
+int SyncFile<I>::fdatasync() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << dendl;
+
+  int r = ::fdatasync(m_fd);
+  if (r == -1) {
+    r = -errno;
+    return r;
+  }
+  return 0;
+}
+
+template <typename I>
+uint64_t SyncFile<I>::filesize() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << dendl;
+
+  struct stat file_st;
+  memset(&file_st, 0, sizeof(file_st));
+  fstat(m_fd, &file_st);
+  return file_st.st_size;
+}
+
+} // namespace file
+} // namespace cache
+} // namespace librbd
+
+template class librbd::cache::file::SyncFile<librbd::ImageCtx>;

--- a/src/librbd/cache/file/SyncFile.h
+++ b/src/librbd/cache/file/SyncFile.h
@@ -1,0 +1,65 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CACHE_FILE_AIO_FILE
+#define CEPH_LIBRBD_CACHE_FILE_AIO_FILE
+
+#include "include/buffer_fwd.h"
+#include <string>
+
+struct Context;
+struct ContextWQ;
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace cache {
+namespace file {
+
+template <typename ImageCtxT>
+class SyncFile {
+public:
+  SyncFile(ImageCtxT &image_ctx, ContextWQ &work_queue, const std::string &name);
+  ~SyncFile();
+
+  // TODO use IO queue instead of individual commands so operations can be
+  // submitted in batch
+
+  // TODO use scatter/gather API
+
+  void open(Context *on_finish);
+  void close(Context *on_finish);
+
+  void read(uint64_t offset, uint64_t length, ceph::bufferlist *bl,
+            Context *on_finish);
+  void write(uint64_t offset, ceph::bufferlist &&bl, bool fdatasync,
+             Context *on_finish);
+  void discard(uint64_t offset, uint64_t length,
+               bool fdatasync, Context *on_finish);
+  void truncate(uint64_t length, bool fdatasync, Context *on_finish);
+
+  void fsync(Context *on_finish);
+  void fdatasync(Context *on_finish);
+  uint64_t filesize();
+
+private:
+  ImageCtxT &m_image_ctx;
+  ContextWQ &m_work_queue;
+  std::string m_name;
+  int m_fd = -1;
+
+  int write(uint64_t offset, const ceph::bufferlist &bl, bool fdatasync);
+  int read(uint64_t offset, uint64_t length, ceph::bufferlist *bl);
+  int discard(uint64_t offset, uint64_t length, bool fdatasync);
+  int truncate(uint64_t length, bool fdatasync);
+  int fdatasync();
+};
+
+} // namespace file
+} // namespace cache
+} // namespace librbd
+
+extern template class librbd::cache::file::SyncFile<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_CACHE_FILE_AIO_FILE

--- a/src/librbd/cache/file/SyncFile.h
+++ b/src/librbd/cache/file/SyncFile.h
@@ -28,7 +28,7 @@ public:
 
   // TODO use scatter/gather API
 
-  void open(Context *on_finish);
+  void open(Context *on_finish, bool sync_flag = true);
   void close(Context *on_finish);
 
   void read(uint64_t offset, uint64_t length, ceph::bufferlist *bl,

--- a/src/librbd/cache/file/Types.cc
+++ b/src/librbd/cache/file/Types.cc
@@ -10,16 +10,19 @@ namespace file {
 
 namespace stupid_policy {
 void Entry_t::encode(bufferlist& bl) const {
-  ENCODE_START(1, 1, bl);
-  ::encode(dirty, bl);
-  ::encode(block, bl);
-  ENCODE_FINISH(bl);
+  //ENCODE_START(1, 1, bl);
+  uint64_t tmp;
+  tmp = dirty << 56 & block;
+  bl.push_back(buffer::copy((char*)&tmp, sizeof(uint64_t)));
+  //ENCODE_FINISH(bl);
 }
 
 void Entry_t::decode(bufferlist::iterator& it) {
   DECODE_START(1, it);
-  ::decode(dirty, it);
-  ::decode(block, it);
+  uint64_t tmp;
+  ::decode(tmp, it);
+  dirty = block >> 56;
+  block = tmp & 0x0FFFFFFF;
   DECODE_FINISH(it);
 }
 


### PR DESCRIPTION
Some optimization
1. thread model to multiple
2. SyncFile replace AioFile
3. open meta wo sync flag to using fs buffer first, todo: add a buffer write backend
4. disable writeback flush to see the performance, todo: need to refine writeback logic to make it more smart
5. refine meta data structure, now it only write 8 bytes into meta file
6. move allocate_tid into partial write, todo: need to make backend log-append to ensure the consistency.