### PR TITLE
Change Policy to use free append strategy

### DIFF
--- a/src/librbd/cache/Block.h
+++ b/src/librbd/cache/Block.h
@@ -1,0 +1,69 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_CACHE_BLOCK_MAP
+#define CEPH_LIBRBD_CACHE_BLOCK_MAP
+
+#include "librbd/cache/Types.h" 
+#include "include/lru.h"
+#include <mutex>
+#include <unordered_map>
+
+namespace librbd {
+namespace cache {
+ 
+struct Entry : public LRUObject {
+  uint64_t on_disk_id;
+  Entry() : on_disk_id(0) {}
+};
+
+struct Block {
+  std::mutex lock;
+
+  uint64_t block;
+  Entry* entry;
+  uint8_t status;
+
+  void *tail_block_io_request; ///< used to track ios on this block
+  bool in_process;        ///< true if this block has been in processing by thread
+  Block( uint64_t block ) : block(block),
+      entry(nullptr), status(NOT_IN_CACHE),
+      tail_block_io_request(nullptr),
+      in_process(false) {}
+};
+
+class BlockMap {
+public:
+  //chendi: add an universal map to pre-allocate in memory data for each block
+  typedef std::unordered_map<uint64_t, Block*> BlockToBlocksMap;
+  BlockToBlocksMap m_block_map;
+  uint64_t m_block_count = 0;
+
+  BlockMap(uint64_t block_count): m_block_count(block_count) {
+    for(uint64_t block = 0; block < m_block_count; block++) {
+      //chendi: initiate universal BlockIOMap
+      Block* block_info = new Block(block);
+      m_block_map.insert(std::make_pair(block, block_info));
+    }
+  }
+
+  Block* find_block(uint64_t block_id) {
+    auto block_it = m_block_map.find(block_id);
+    if(block_it == m_block_map.end())
+      return nullptr;
+    else
+      return block_it->second;
+  }
+
+  BlockToBlocksMap::iterator begin() {
+    return m_block_map.begin();
+  }
+
+  BlockToBlocksMap::iterator end() {
+    return m_block_map.end();
+  }
+
+};
+} //end of namespace cache
+} //end of namespace librbd
+#endif

--- a/src/librbd/cache/BlockGuard.h
+++ b/src/librbd/cache/BlockGuard.h
@@ -8,6 +8,7 @@
 #include "include/Context.h"
 #include "common/Mutex.h"
 #include "librbd/cache/Types.h"
+#include "librbd/cache/Block.h"
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/unordered_set.hpp>
 #include <boost/variant.hpp>
@@ -63,6 +64,7 @@ public:
   struct C_BlockIORequest : public Context {
     CephContext *cct;
     C_BlockIORequest *next_block_request;
+    uint16_t inflight_requests_count;
   
     C_BlockIORequest(CephContext *cct, C_BlockIORequest *next_block_request)
       : cct(cct), next_block_request(next_block_request) {
@@ -91,26 +93,10 @@ public:
     virtual void* get_buffer_ptr(){ return nullptr; }
   };
 
-  struct Block {
-    Block( uint64_t block )
-     : /*lock("librbd::cache::BlockGuard::Block::lock"),*/
-       block(block), status(0), tail_block_io_request(nullptr),
-       in_process(false) {
-    }
-    //Mutex lock;
-    std::mutex lock;
-    uint64_t block;
-    uint8_t status; //0x00 non-exist, 0x01 clean, 0x02 dirty
-    C_BlockIORequest *tail_block_io_request; ///< used to track ios on this block
-    bool in_process;        ///< true if this block has been in processing by thread
-  };
 
-  typedef std::unordered_map<uint64_t, Block*> BlockToBlocksMap;
   struct BlockIO {
     // TODO intrusive_list
     Block *block_info;
-    uint64_t block;
-    uint64_t tid;
     BlockIOExtents extents;
     IOType io_type : 2;     ///< IO type for deferred IO request
     bool partial_block : 1; ///< true if not full block request
@@ -131,6 +117,9 @@ public:
   //int detain(uint64_t block, BlockIO *block_io){return 0;}
   // release detained IO against a specified block
   //int release(uint64_t block, BlockIOs *block_ios){return 0;}
+  inline void set_block_map(void* block_map) {
+    m_block_map = (BlockMap*)block_map;
+  }
   inline friend std::ostream &operator<<(std::ostream &os,
                                          const BlockIOExtent& rhs) {
     os << "buffer_offset=" << rhs.buffer_offset << ", "
@@ -140,7 +129,7 @@ public:
   }
   inline friend std::ostream &operator<<(std::ostream &os,
                                          const BlockIO& rhs) {
-    os << "block=" << rhs.block << ", "
+    os << "block=" << rhs.block_info->block << ", "
        << "io_type=" << rhs.io_type << ", "
        << "[";
     std::string delim;
@@ -156,12 +145,10 @@ private:
   CephContext *m_cct;
   uint32_t m_max_blocks;
   uint32_t m_block_size;
+  BlockMap* m_block_map;
 
   Mutex m_lock;
 
-  //chendi: add an universal map to pre-allocate in memory data for each block
-  BlockToBlocksMap m_Block_map;
-  
 };
 
 } // namespace cache

--- a/src/librbd/cache/Types.h
+++ b/src/librbd/cache/Types.h
@@ -10,9 +10,10 @@
 namespace librbd {
 namespace cache {
 
-#define LOCATE_IN_BASE_CACHE 0XF0
-#define LOCATE_IN_CACHE      0XF1
-#define NOT_IN_CACHE         0XF2
+#define MAX_BLOCK_ID         0X3FFFFFFF
+#define LOCATE_IN_BASE_CACHE 0X01
+#define LOCATE_IN_CACHE      0X02
+#define NOT_IN_CACHE         0X03
 
 enum PolicyMapResult {
   POLICY_MAP_RESULT_HIT,    // block is already in cache

--- a/src/librbd/cache/file/ImageStore.h
+++ b/src/librbd/cache/file/ImageStore.h
@@ -7,7 +7,6 @@
 #include "include/buffer_fwd.h"
 #include "include/int_types.h"
 #include "os/CacheStore/SyncFile.h"
-#include "librbd/cache/file/StupidPolicy.cc"
 #include <vector>
 
 struct Context;
@@ -26,23 +25,22 @@ class ImageStore {
 public:
   typedef std::vector<std::pair<uint32_t, uint32_t> > BlockExtents;
 
-  ImageStore(ImageCtxT &image_ctx, Policy &policy, uint64_t image_size, std::string volumd_name);
+  ImageStore(ImageCtxT &image_ctx, uint64_t image_size, std::string volumd_name);
 
   void init(Context *on_finish);
   void remove(Context *on_finish);
   void shut_down(Context *on_finish);
   void reset(Context *on_finish);
 
-  void read_block(uint64_t cache_block, BlockExtents &&block_extents,
+  void read_block(uint64_t offset, BlockExtents &&block_extents,
                   ceph::bufferlist *bl, Context *on_finish);
-  void write_block(uint64_t cache_block, BlockExtents &&block_extents,
+  void write_block(uint64_t offset, BlockExtents &&block_extents,
                    ceph::bufferlist &&bl, Context *on_finish);
   void discard_block(uint64_t cache_block, Context *on_finish);
   bool check_exists();
 
 private:
   ImageCtxT &m_image_ctx;
-  Policy &m_policy;
   uint64_t m_image_size;
   os::CacheStore::SyncFile m_cache_file;
 

--- a/src/librbd/cache/file/MetaStore.cc
+++ b/src/librbd/cache/file/MetaStore.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "librbd/cache/file/MetaStore.h"
+#include "librbd/cache/Types.h"
 #include "include/stringify.h"
 #include "common/dout.h"
 #include "librbd/ImageCtx.h"
@@ -20,20 +21,28 @@ template <typename I>
 MetaStore<I>::MetaStore(I &image_ctx, uint64_t block_count)
   : m_image_ctx(image_ctx), m_block_count(block_count),
     m_meta_file(image_ctx.cct, *image_ctx.op_work_queue, image_ctx.id + ".meta"), init_m_loc_map(false) {
-    //m_lock("librbd::cache::file::MetaStore::m_lock") {
-      //m_loc_map = new uint8_t[block_count]();
 }
 
 template <typename I>
 void MetaStore<I>::init(Context *on_finish) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << dendl;
+  Context* ctx;
 
   // TODO
   if (!m_meta_file.try_open()) {
     init_m_loc_map = true;
   }
-  m_meta_file.open(on_finish);
+  ctx = new FunctionContext(
+    [this, on_finish](int r) {
+      if (r < 0) {
+        on_finish->complete(r);
+      } else {
+        assert(m_meta_file.load((void**)&m_loc_map, m_block_count * sizeof(uint32_t)) == 0);
+        on_finish->complete(r);
+      }
+  });
+  m_meta_file.open(ctx);
 }
 
 template <typename I>
@@ -54,24 +63,34 @@ void MetaStore<I>::shut_down(Context *on_finish) {
 }
 
 template <typename I>
-void MetaStore<I>::load(uint8_t loc) {
-  assert(m_meta_file.load((void**)&m_loc_map, m_block_count) == 0);
+void MetaStore<I>::load(uint32_t loc) {
+  uint32_t tmp;
   if (init_m_loc_map) {
     for(uint64_t block = 0; block < m_block_count; block++) {
-      m_loc_map[block] = loc;
+      switch(loc) {
+        case NOT_IN_CACHE:
+          m_loc_map[block] = (loc << 30);
+          break;
+        case LOCATE_IN_BASE_CACHE:
+          tmp = loc << 30;
+          m_loc_map[block] = tmp | block;
+          break;
+        default:
+          assert(0);
+      }
     }
   }
 }
 
 template <typename I>
-void MetaStore<I>::update(uint64_t block_id, uint8_t loc) {
+void MetaStore<I>::update(uint64_t block_id, uint32_t loc) {
   //Mutex::Locker locker(m_lock);
   std::lock_guard<std::mutex> lock(m_lock);
   m_loc_map[block_id] = loc;
 }
 
 template <typename I>
-void MetaStore<I>::get_loc_map(uint8_t* dest) {
+void MetaStore<I>::get_loc_map(uint32_t* dest) {
   for(uint64_t block = 0; block < m_block_count; block++) {
     dest[block] = m_loc_map[block];
   }

--- a/src/librbd/cache/file/MetaStore.h
+++ b/src/librbd/cache/file/MetaStore.h
@@ -25,14 +25,14 @@ public:
   void init(Context *on_finish);
   void remove(Context *on_finish);
   void shut_down(Context *on_finish);
-  void update(uint64_t block_id, uint8_t loc);
-  void get_loc_map(uint8_t *dest);
-  void load(uint8_t loc);
+  void update(uint64_t block_id, uint32_t loc);
+  void get_loc_map(uint32_t *dest);
+  void load(uint32_t loc);
 
 private:
   ImageCtxT &m_image_ctx;
   uint64_t m_block_count;
-  uint8_t *m_loc_map;
+  uint32_t *m_loc_map;
   //mutable Mutex m_lock;
   std::mutex m_lock;
   bool init_m_loc_map;

--- a/src/librbd/cache/file/Policy.h
+++ b/src/librbd/cache/file/Policy.h
@@ -17,6 +17,7 @@ namespace file {
  */
 class Policy {
 public:
+  uint64_t m_block_size = 4096;
   virtual ~Policy() {
   }
 
@@ -25,16 +26,19 @@ public:
   virtual int invalidate(uint64_t block) = 0;
 
   virtual int map(IOType io_type, uint64_t block, bool partial_block,
-                  PolicyMapResult *policy_map_result,
-                  bool in_base_cache = false) = 0;
+                  PolicyMapResult *policy_map_result) = 0;
   virtual void tick() = 0;
-  virtual uint64_t offset_to_block(uint64_t offset) = 0;
-  virtual uint64_t block_to_offset(uint64_t block) = 0;
   virtual uint64_t get_block_count() = 0;
   virtual void set_to_base_cache(uint64_t block) = 0;
-  virtual uint8_t get_loc(uint64_t block) = 0;
-  virtual void set_loc(uint8_t *src) = 0;
-
+  virtual uint32_t get_loc(uint64_t block) = 0;
+  virtual void set_loc(uint32_t *src) = 0;
+  virtual uint64_t block_to_offset(uint64_t block) {
+    return block * m_block_size;
+  }
+  virtual uint64_t offset_to_block(uint64_t offset){
+    return offset / m_block_size;
+  }
+  virtual void* get_block_map() = 0;
 };
 
 } // namespace file

--- a/src/librbd/cache/file/StupidPolicy.cc
+++ b/src/librbd/cache/file/StupidPolicy.cc
@@ -4,7 +4,6 @@
 #include "librbd/cache/file/StupidPolicy.h"
 #include "common/dout.h"
 #include "librbd/ImageCtx.h"
-#include "librbd/cache/BlockGuard.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -16,16 +15,19 @@ namespace cache {
 namespace file {
 
 template <typename I>
-StupidPolicy<I>::StupidPolicy(I &image_ctx, BlockGuard &block_guard)
-  : m_image_ctx(image_ctx), m_block_guard(block_guard),
+StupidPolicy<I>::StupidPolicy(I &image_ctx)
+  : m_image_ctx(image_ctx),
     m_lock("librbd::cache::file::StupidPolicy::m_lock") {
 
   set_block_count(offset_to_block(image_ctx.size));
   // TODO support resizing of entries based on number of provisioned blocks
-  m_entries.resize(m_block_count); // 1GB of storage
+  m_entries.resize(offset_to_block(image_ctx.ssd_cache_size < m_image_ctx.size?image_ctx.ssd_cache_size:m_image_ctx.size)); // 1GB of storage
+  uint64_t block_id = 0;
   for (auto &entry : m_entries) {
+    entry.on_disk_id = block_id++;
     m_free_lru.insert_tail(&entry);
   }
+  m_block_map = new BlockMap(m_block_count);
 }
 
 template <typename I>
@@ -36,25 +38,20 @@ void StupidPolicy<I>::set_block_count(uint64_t block_count) {
   // TODO ensure all entries are in-bound
   Mutex::Locker locker(m_lock);
   m_block_count = block_count;
-
 }
 
 template <typename I>
 int StupidPolicy<I>::invalidate(uint64_t block) {
   CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 20) << "block=" << block << dendl;
+  ldout(cct, 1) << "block=" << block << dendl;
 
   // TODO handle case where block is in prison (shouldn't be possible
   // if core properly registered blocks)
 
   Mutex::Locker locker(m_lock);
-  auto entry_it = m_block_to_entries.find(block);
-  if (entry_it == m_block_to_entries.end()) {
-    return 0;
-  }
-
-  Entry *entry = entry_it->second;
-  m_block_to_entries.erase(entry_it);
+  Block* block_info = m_block_map->find_block(block);
+  assert(block_info != nullptr);
+  Entry *entry = block_info->entry;
 
   LRUList *lru;
   lru = &m_clean_lru;
@@ -66,8 +63,7 @@ int StupidPolicy<I>::invalidate(uint64_t block) {
 
 template <typename I>
 int StupidPolicy<I>::map(IOType io_type, uint64_t block, bool partial_block,
-                         PolicyMapResult *policy_map_result,
-                         bool in_base_cache) {
+                         PolicyMapResult *policy_map_result) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "block=" << block << dendl;
 
@@ -80,60 +76,80 @@ int StupidPolicy<I>::map(IOType io_type, uint64_t block, bool partial_block,
   }
 
   Entry *entry;
-  auto entry_it = m_block_to_entries.find(block);
-  if (entry_it != m_block_to_entries.end()) {
+  Block* block_info = m_block_map->find_block(block);
+  assert (block_info != nullptr);
+  {
     // cache hit -- move entry to the front of the queue
-    entry = entry_it->second;
-    LRUList *lru;
-    lru = &m_clean_lru;
+    entry = block_info->entry;
     
-    if (io_type != IO_TYPE_READ) {
-      *policy_map_result = POLICY_MAP_RESULT_HIT;
-      if( entry->in_base_cache ) {
-        entry->in_base_cache = false;
+    if (io_type == IO_TYPE_WRITE) {
+      ldout(cct, 1) << "io_type == write, block: " << block << dendl;
+      switch(block_info->status) {
+        case LOCATE_IN_CACHE:
+          *policy_map_result = POLICY_MAP_RESULT_HIT;
+          m_clean_lru.remove(entry);
+          m_free_lru.insert_tail(entry);
+          block_info->status = NOT_IN_CACHE;
+          break;
+        case LOCATE_IN_BASE_CACHE:
+          *policy_map_result = POLICY_MAP_RESULT_HIT_IN_BASE;
+          block_info->status = NOT_IN_CACHE;
+          break;
+        case NOT_IN_CACHE:
+        default:
+          *policy_map_result = POLICY_MAP_RESULT_MISS;
+          block_info->status = NOT_IN_CACHE; 
+          break;
       }
-      lru->remove(entry);
-      m_free_lru.insert_tail(entry);
-      m_block_to_entries.erase(entry_it);
       return 0;
     }
-    if( entry->in_base_cache ) {
-      ldout(cct, 1) << "cache hit in base snap, blocks: " << block << dendl;
-      *policy_map_result = POLICY_MAP_RESULT_HIT_IN_BASE;
-    } else {
-      ldout(cct, 1) << "cache hit, block: " << block << dendl;
-      *policy_map_result = POLICY_MAP_RESULT_HIT;
+    switch(block_info->status) {
+      case LOCATE_IN_CACHE:
+        entry = block_info->entry;
+        assert(entry != nullptr);
+        *policy_map_result = POLICY_MAP_RESULT_HIT;
+        m_clean_lru.remove(entry);
+        m_clean_lru.insert_head(entry);
+        ldout(cct, 1) << "cache hit, block: " << block << dendl;
+        break;
+      case LOCATE_IN_BASE_CACHE:
+        *policy_map_result = POLICY_MAP_RESULT_HIT_IN_BASE;
+        ldout(cct, 1) << "cache hit in base, block: " << block << dendl;
+        break;
+      case NOT_IN_CACHE:
+      default:
+        entry = reinterpret_cast<Entry*>(m_free_lru.get_head());
+        if (entry != nullptr) {
+          ldout(cct, 1) << "cache miss -- new entry, block: " << block << dendl;
+          *policy_map_result = POLICY_MAP_RESULT_NEW;
+          m_free_lru.remove(entry);
+          m_clean_lru.insert_head(entry);
+          block_info->entry = entry;
+          block_info->status = LOCATE_IN_CACHE;
+        } else {
+          ldout(cct, 1) << "cache miss, no free slot in cache. block: " << block << dendl;
+          *policy_map_result = POLICY_MAP_RESULT_MISS;
+        }
+        break;
     }
-
-    lru->remove(entry);
-    lru->insert_head(entry);
-    return 0;
   }
-
-  if (io_type != IO_TYPE_READ) {
-    *policy_map_result = POLICY_MAP_RESULT_MISS;
-    return 0;
-  }
-  // cache miss
-  entry = reinterpret_cast<Entry*>(m_free_lru.get_head());
-  if (entry != nullptr) {
-    // entries are available -- allocate a slot
-    ldout(cct, 1) << "cache miss -- new entry, block: " << block << dendl;
-    *policy_map_result = POLICY_MAP_RESULT_NEW;
-    m_free_lru.remove(entry);
-
-    entry->block = block;
-    entry->in_base_cache = in_base_cache;
-    m_block_to_entries[block] = entry;
-    m_clean_lru.insert_head(entry);
-    return 0;
-  } else {
-    ldout(cct, 1) << "cache miss: " << block << dendl;
-  }
-
-  // no clean entries to evict -- treat this as a miss
-  *policy_map_result = POLICY_MAP_RESULT_MISS;
   return 0;
+}
+
+template <typename I>
+uint64_t StupidPolicy<I>::block_to_offset(uint64_t block) {
+  CephContext *cct = m_image_ctx.cct;
+  Mutex::Locker locker(m_lock);
+  Block* block_info = m_block_map->find_block(block);
+  switch (block_info->status) {
+    case LOCATE_IN_CACHE:
+      return block_info->entry->on_disk_id * m_block_size;
+    case LOCATE_IN_BASE_CACHE:
+      return block_info->block * m_block_size;
+    case NOT_IN_CACHE:
+      ldout(cct, 1) << "This block is not in cache, block: " << block << dendl;
+      assert(0);
+  }
 }
 
 template <typename I>
@@ -143,55 +159,63 @@ void StupidPolicy<I>::tick() {
 
 template <typename I>
 void StupidPolicy<I>::set_to_base_cache(uint64_t block) {
-  Mutex::Locker locker(m_lock);
-  auto entry_it = m_block_to_entries.find(block);
-  assert(entry_it != m_block_to_entries.end());
-  Entry* entry = entry_it->second;
-  entry->in_base_cache = true;
+  Block* block_info = m_block_map->find_block(block);
+  block_info->status = LOCATE_IN_BASE_CACHE;
 }
 
 template <typename I>
-uint8_t StupidPolicy<I>::get_loc(uint64_t block) {
+uint32_t StupidPolicy<I>::get_loc(uint64_t block) {
   Mutex::Locker locker(m_lock);
-  Entry *entry;
-  auto entry_it = m_block_to_entries.find(block);
-  if (entry_it != m_block_to_entries.end()) {
-    entry = entry_it->second;
-    if (entry->in_base_cache)
-      return LOCATE_IN_BASE_CACHE;
-    else
-      return LOCATE_IN_CACHE;
+  uint32_t ret_data;
+  Block* block_info = m_block_map->find_block(block);
+  assert (block_info != nullptr);
+  switch( block_info->status ) {
+    case LOCATE_IN_BASE_CACHE:
+      ret_data = ( block | (block_info->status << 30) ) ; 
+      return ret_data;
+    case LOCATE_IN_CACHE:
+      assert(block_info->entry->on_disk_id <= MAX_BLOCK_ID);
+      ret_data = ( block_info->entry->on_disk_id | (block_info->status << 30) ); 
+      return ret_data;
+    case NOT_IN_CACHE:
+    default:
+      return (NOT_IN_CACHE << 30);
   }
-  return NOT_IN_CACHE;
 }
 
 template <typename I>
-void StupidPolicy<I>::set_loc(uint8_t *src) {
+void StupidPolicy<I>::set_loc(uint32_t *src) {
+  Mutex::Locker locker(m_lock);
   Entry* entry;
-  for(uint64_t block_id = 0; block_id < m_block_count; block_id++) {
-    switch(src[block_id]) {
-      case NOT_IN_CACHE:
-        break;
+  uint8_t loc;
+  uint64_t on_disk_id;
+  uint64_t block_id;
+  for(auto block_it = m_block_map->begin(); block_it != m_block_map->end(); block_it++) {
+    block_id = block_it->second->block;
+    loc = src[block_id] >> 30;
+    switch(loc) {
       case LOCATE_IN_CACHE:
-        entry = reinterpret_cast<Entry*>(m_free_lru.get_head());
-        entry->in_base_cache = false;
-        entry->block = block_id;
+        on_disk_id = (src[block_id] & MAX_BLOCK_ID);
+        entry = &m_entries[on_disk_id];
+        assert(entry != nullptr);
         m_free_lru.remove(entry);
-        m_block_to_entries[block_id] = entry;
         m_clean_lru.insert_head(entry);
+        block_it->second->entry = entry;
+        block_it->second->status = LOCATE_IN_CACHE;
         break;
       case LOCATE_IN_BASE_CACHE:
+        on_disk_id = (src[block_id] & MAX_BLOCK_ID);
+        assert(on_disk_id == block_id);
+        block_it->second->status = LOCATE_IN_BASE_CACHE;
+        break;
+      case NOT_IN_CACHE:
       default:
-        entry = reinterpret_cast<Entry*>(m_free_lru.get_head());
-        entry->in_base_cache = true;
-        entry->block = block_id;
-        m_free_lru.remove(entry);
-        m_block_to_entries[block_id] = entry;
-        m_clean_lru.insert_head(entry);
+        block_it->second->status = NOT_IN_CACHE;
         break;
     }
   }
 }
+
 
 } // namespace file
 } // namespace cache

--- a/src/librbd/cache/file/StupidPolicy.h
+++ b/src/librbd/cache/file/StupidPolicy.h
@@ -4,10 +4,9 @@
 #ifndef CEPH_LIBRBD_CACHE_FILE_STUPID_POLICY
 #define CEPH_LIBRBD_CACHE_FILE_STUPID_POLICY
 
+#include "librbd/cache/Block.h"
 #include "librbd/cache/file/Policy.h"
-#include "include/lru.h"
 #include "common/Mutex.h"
-#include "librbd/cache/file/Types.h"
 #include <unordered_map>
 #include <vector>
 
@@ -17,8 +16,6 @@ struct ImageCtx;
 
 namespace cache {
 
-struct BlockGuard;
-
 namespace file {
 
 /**
@@ -27,57 +24,38 @@ namespace file {
 template <typename ImageCtxT>
 class StupidPolicy : public Policy {
 private:
-
-  struct Entry : public LRUObject {
-    uint64_t block;
-    bool in_base_cache;
-    Entry() : block(0), in_base_cache(false) {
-    }
-  };
-
   typedef std::vector<Entry> Entries;
-  typedef std::unordered_map<uint64_t, Entry*> BlockToEntries;
 
   ImageCtxT &m_image_ctx;
-  BlockGuard &m_block_guard;
-  uint64_t m_block_size = 4096;
-
   mutable Mutex m_lock;
-  uint64_t m_block_count = 0;
-
   Entries m_entries;
-  BlockToEntries m_block_to_entries;
+  BlockMap* m_block_map;
+  uint64_t m_block_count;
 
   LRUList m_free_lru;
   LRUList m_clean_lru;
 
 public:
-  StupidPolicy(ImageCtxT &image_ctx, BlockGuard &block_guard);
+  StupidPolicy(ImageCtxT &image_ctx);
 
   virtual void set_block_count(uint64_t block_count);
 
   virtual int invalidate(uint64_t block);
 
   virtual int map(IOType io_type, uint64_t block, bool partial_block,
-                  PolicyMapResult *policy_map_result,
-                  bool in_base_cache = false);
+                  PolicyMapResult *policy_map_result);
   virtual void tick();
   void set_to_base_cache(uint64_t block);
-  inline uint64_t offset_to_block(uint64_t offset) {
-    return offset / m_block_size;
-  }
+  uint64_t block_to_offset(uint64_t block) override;
 
-  inline uint64_t block_to_offset(uint64_t block) {
-    return block * m_block_size;
-  }
-  
-  inline uint64_t get_block_count(){
+  virtual uint32_t get_loc(uint64_t block);
+  virtual void set_loc(uint32_t *src);
+  inline uint64_t get_block_count() {
     return m_block_count;
   }
-
-  virtual uint8_t get_loc(uint64_t block);
-  virtual void set_loc(uint8_t *src);
-
+  inline void* get_block_map() {
+    return m_block_map;
+  }
 };
 
 } // namespace file

--- a/src/librbd/cache/file/Types.h
+++ b/src/librbd/cache/file/Types.h
@@ -23,16 +23,6 @@ namespace file {
  * Persistent on-disk cache structures
  */
 
-namespace stupid_policy {
-
-struct Entry {
-  bool dirty;
-  bool allocated;
-  uint64_t block;
-};
-
-} // namespace stupid_policy
-
 namespace meta_store {
 
 struct Header {


### PR DESCRIPTION
Original volume offset to cache offset mapping
uses volume_offset / 4096, which requires cache
size same as volume size.
So change the logic to free and append, and add
cache offset to metadata to reload.

Refactor to add a Block.h for whole volume map

1. Block.h is used for whole volume map
2. StupidPolicy/entries is used for cache map
3. Use block->entry and block_status to mark both cache in parent_snap
or in local cache

Signed-off-by: Chendi.Xue <chendi.xue@intel.com>